### PR TITLE
Independent ilastik checks

### DIFF
--- a/.github/workflows/check_compatibility_ilastik.yaml
+++ b/.github/workflows/check_compatibility_ilastik.yaml
@@ -35,7 +35,7 @@ jobs:
         with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
           print(f"version_matrix={version_matrix}", file=fh)
 
-  run:
+  generate-reports:
     runs-on: ubuntu-latest
     needs: setup
     strategy:
@@ -43,12 +43,8 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.version_matrix) }}
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/checkout@v3
-      with:
-        repository: bioimage-io/collection-bioimage-io
-        ref: gh-pages
-        path: bioimageio-gh-pages
+    - run: wget https://${{vars.S3_HOST}}/${{vars.S3_BUCKET}}/${{vars.S3_FOLDER}}/all_versions_draft.json
+    - run: wget https://${{vars.S3_HOST}}/${{vars.S3_BUCKET}}/${{vars.S3_FOLDER}}/all_versions.json
     - name: Download ilastik env
       run: wget --output-document env.yaml ${{ matrix.env_url }}
     - name: ignore unrelated packages
@@ -59,9 +55,30 @@ jobs:
         environment-file: env.yaml
         cache-downloads: true
         cache-environment: true
-    - name: install backoffice
+    - name: test drafts with ilastik ${{ matrix.v }}
       shell: bash -l {0}
-      run: pip install .
-    - name: test with ilastik ${{ matrix.v }}
+      run: python scripts/check_compatibility_ilastik.py ${{ matrix.v }} all_versions_draft.json generated-reports
+    - name: test published versions with ilastik ${{ matrix.v }}
       shell: bash -l {0}
-      run: python scripts/check_compatibility_ilastik.py ${{ matrix.v }}
+      run: python scripts/check_compatibility_ilastik.py ${{ matrix.v }} all_versions.json generated-reports
+    - uses: actions/upload-artifact@v4
+      with:
+        name: generated-reports
+        path: generated-reports
+
+  upload-reports:
+    needs: generate-reports
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+        cache: "pip" # caching pip dependencies
+    - run: pip install .
+    - uses: actions/download-artifact@v4
+      with:
+        name: generated-reports
+        path: generated-reports
+    - run: python scripts/upload_reports.py generated-reports
+

--- a/bioimageio_collection_backoffice/remote_collection.py
+++ b/bioimageio_collection_backoffice/remote_collection.py
@@ -575,7 +575,7 @@ class Uploader(NamedTuple):
 
 @dataclass
 class RecordBase(RemoteBase, ABC):
-    """Base class for a `RemoteDraft` and `RemoteVersion`"""
+    """Base class for a `RecordDraft` and `Record`"""
 
     concept_id: str
     concept: RecordConcept = field(init=False)
@@ -655,6 +655,13 @@ class RecordBase(RemoteBase, ABC):
         return [
             f"{self.folder}files/{p}" for p in self.client.ls(f"{self.folder}files/")
         ]
+
+    def get_compatibility_report_path(self, tool: str):
+        return f"{self.folder}compatibility/{tool}.json"
+
+    def set_compatibility_report(self, report: CompatiblityReport) -> None:
+        path = self.get_compatibility_report_path(report.tool)
+        self.client.put_and_cache(path, report.model_dump_json().encode())
 
 
 @dataclass
@@ -963,13 +970,6 @@ class Record(RecordBase):
 
     def update_info(self, update: RecordInfo):
         self._update_json(update)
-
-    def get_compatibility_report_path(self, tool: str):
-        return f"{self.folder}compatibility/{tool}.json"
-
-    def set_compatibility_report(self, report: CompatiblityReport) -> None:
-        path = self.get_compatibility_report_path(report.tool)
-        self.client.put_and_cache(path, report.model_dump_json().encode())
 
     def get_all_compatibility_reports(self, tool: Optional[str] = None):
         """get all compatibility reports"""

--- a/scripts/check_compatibility_ilastik.py
+++ b/scripts/check_compatibility_ilastik.py
@@ -1,15 +1,10 @@
 import argparse
 import warnings
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional, Sequence, Union
 
 import bioimageio.core
 from ruyaml import YAML
-
-from bioimageio_collection_backoffice.db_structure.compatibility import (
-    CompatiblityReport,
-)
-from bioimageio_collection_backoffice.remote_collection import Record, RemoteCollection
-from bioimageio_collection_backoffice.s3_client import Client
+from typing_extensions import Literal, TypedDict
 
 if bioimageio.core.__version__.startswith("0.5."):
     from bioimageio.core import test_resource as test_model
@@ -17,6 +12,20 @@ else:
     from bioimageio.core import test_model
 
 yaml = YAML(typ="safe")
+
+
+class CompatiblityReport(TypedDict):
+    status: Literal["passed", "failed", "not-applicable"]
+    """status of this tool for this resource"""
+
+    error: Optional[str]
+    """error message if `status`=='failed'"""
+
+    details: Any
+    """details to explain the `status`"""
+
+    links: Sequence[str]
+    """the checked resource should link these other bioimage.io resources"""
 
 
 def check_compatibility_ilastik_impl(

--- a/scripts/check_compatibility_ilastik.py
+++ b/scripts/check_compatibility_ilastik.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 
 import bioimageio.core
 import requests
-from ruyaml import YAML
 from tqdm import tqdm
 
 if bioimageio.core.__version__.startswith("0.5."):
@@ -16,8 +15,6 @@ else:
     from bioimageio.core import test_model
 
 from script_utils import CompatiblityReport, download_rdf
-
-yaml = YAML(typ="safe")
 
 
 def check_compatibility_ilastik_impl(
@@ -57,7 +54,7 @@ def check_compatibility_ilastik_impl(
         )
 
     with report_path.open("wt", encoding="utf-8") as f:
-        yaml.dump(report, f)
+        json.dump(report, f)
 
 
 def check_compatibility_ilastik(
@@ -79,17 +76,19 @@ def check_compatibility_ilastik(
             rdf_url = version["source"]
             sha256 = version["sha256"]
 
-            report_path = (
-                "/".join(rdf_url.split("/")[-4:-2])
+            report_url = (
+                "/".join(rdf_url.split("/")[:-2])
                 + f"/compatibility/ilastik_{ilastik_version}.yaml"
             )
-            report_url = "/".join(rdf_url.split("/")[:-4]) + f"/{report_path}"
-
             r = requests.head(report_url)
             if r.status_code != 404:
                 r.raise_for_status()  # raises if failed to check if report exists
                 continue  # report already exists
 
+            report_path = (
+                "/".join(rdf_url.split("/")[-4:-2])
+                + f"/compatibility/ilastik_{ilastik_version}.json"
+            )
             try:
                 check_compatibility_ilastik_impl(
                     rdf_url, sha256, output_folder / report_path

--- a/scripts/check_compatibility_ilastik.py
+++ b/scripts/check_compatibility_ilastik.py
@@ -1,98 +1,111 @@
 import argparse
+import json
+import traceback
 import warnings
-from typing import Any, Dict, Optional, Sequence, Union
+from pathlib import Path
+from typing import TYPE_CHECKING
 
 import bioimageio.core
+import requests
 from ruyaml import YAML
-from typing_extensions import Literal, TypedDict
+from tqdm import tqdm
 
 if bioimageio.core.__version__.startswith("0.5."):
     from bioimageio.core import test_resource as test_model
 else:
     from bioimageio.core import test_model
 
+from script_utils import CompatiblityReport, download_rdf
+
 yaml = YAML(typ="safe")
 
 
-class CompatiblityReport(TypedDict):
-    status: Literal["passed", "failed", "not-applicable"]
-    """status of this tool for this resource"""
-
-    error: Optional[str]
-    """error message if `status`=='failed'"""
-
-    details: Any
-    """details to explain the `status`"""
-
-    links: Sequence[str]
-    """the checked resource should link these other bioimage.io resources"""
-
-
 def check_compatibility_ilastik_impl(
-    record: Record,
-    tool: str,
+    rdf_url: str,
+    sha256: str,
+    report_path: Path,
 ):
-    report_path = record.get_compatibility_report_path(tool)
-    if list(record.client.ls(report_path)):
-        return
+    report_path.parent.mkdir(parents=True, exist_ok=True)
 
-    rdf_data = record.client.load_file(record.rdf_path)
-    assert rdf_data is not None
-    rdf: Union[Any, Dict[str, Any]] = yaml.load(rdf_data)
-    assert isinstance(rdf, dict)
-    if rdf.get("type") != "model":
-        return CompatiblityReport(
-            tool=tool,
+    rdf = download_rdf(rdf_url, sha256)
+
+    if rdf["type"] != "model":
+        report = CompatiblityReport(
             status="not-applicable",
             error=None,
             details="only 'model' resources can be used in ilastik.",
         )
 
-    if len(rdf["inputs"]) > 1 or len(rdf["outputs"]) > 1:
-        return CompatiblityReport(
-            tool=tool,
+    elif len(rdf["inputs"]) > 1 or len(rdf["outputs"]) > 1:
+        report = CompatiblityReport(
             status="failed",
             error=f"ilastik only supports single tensor input/output (found {len(rdf['inputs'])}/{len(rdf['outputs'])})",
             details=None,
         )
+    else:
+        # produce test summary with bioimageio.core
+        summary = test_model(rdf_url)
+        if not TYPE_CHECKING:
+            if bioimageio.core.__version__.startswith("0.5."):
+                summary = summary[-1]
 
-    # produce test summaries for each weight format
-    summary = test_model(record.client.get_file_url(record.rdf_path))
-    if bioimageio.core.__version__.startswith("0.5."):
-        summary = summary[-1]  # type: ignore
+        report = CompatiblityReport(
+            status=summary.status,
+            error=None if summary.status == "passed" else summary.format(),
+            details=summary.model_dump(mode="json"),
+            links=["ilastik/ilastik"],
+        )
 
-    return CompatiblityReport(
-        tool=tool,
-        status=summary.status,
-        error=None if summary.status == "passed" else summary.format(),
-        details=summary,
-        links=["ilastik/ilastik"],
-    )
+    with report_path.open("wt", encoding="utf-8") as f:
+        yaml.dump(report, f)
 
 
 def check_compatibility_ilastik(
-    ilastik_version: str,
+    ilastik_version: str, all_version_path: Path, output_folder: Path
 ):
     """preliminary ilastik check
 
     only checks if test outputs are reproduced for onnx, torchscript, or pytorch_state_dict weights.
+    # TODO: test with ilastik itself
 
     """
-    collection = RemoteCollection(Client())
-    for record in collection.get_published_versions():
-        try:
-            report = check_compatibility_ilastik_impl(
-                record, f"ilastik_{ilastik_version}"
+    with all_version_path.open() as f:
+        all_versions = json.load(f)["entries"]
+
+    all_model_versions = [entry for entry in all_versions if entry["type"] == "model"]
+
+    for entry in tqdm(all_model_versions):
+        for version in entry["versions"]:
+            rdf_url = version["source"]
+            sha256 = version["sha256"]
+
+            report_path = (
+                "/".join(rdf_url.split("/")[-4:-2])
+                + f"/compatibility/ilastik_{ilastik_version}.yaml"
             )
-        except Exception as e:
-            warnings.warn(f"failed to check '{record.id}': {e}")
-        else:
-            if report is not None:
-                record.set_compatibility_report(report)
+            report_url = "/".join(rdf_url.split("/")[:-4]) + f"/{report_path}"
+
+            r = requests.head(report_url)
+            if r.status_code != 404:
+                r.raise_for_status()  # raises if failed to check if report exists
+                continue  # report already exists
+
+            try:
+                check_compatibility_ilastik_impl(
+                    rdf_url, sha256, output_folder / report_path
+                )
+            except Exception as e:
+                traceback.print_exc()
+                warnings.warn(f"failed to check '{report_path}': {e}")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     _ = parser.add_argument("ilastik_version")
+    _ = parser.add_argument("all_versions", type=Path)
+    _ = parser.add_argument("output_folder", type=Path)
 
-    check_compatibility_ilastik(parser.parse_args().ilastik_version)
+    args = parser.parse_args()
+    check_compatibility_ilastik(
+        args.ilastik_version, args.all_versions, args.output_folder
+    )

--- a/scripts/script_utils.py
+++ b/scripts/script_utils.py
@@ -1,0 +1,44 @@
+import hashlib
+from typing import Any, Dict, Optional, Sequence, Union
+
+import requests
+from ruyaml import YAML
+from typing_extensions import Literal, NotRequired, TypedDict
+
+yaml = YAML(typ="safe")
+
+
+class CompatiblityReport(TypedDict):
+    status: Literal["passed", "failed", "not-applicable"]
+    """status of this tool for this resource"""
+
+    error: Optional[str]
+    """error message if `status`=='failed'"""
+
+    details: Any
+    """details to explain the `status`"""
+
+    links: NotRequired[Sequence[str]]
+    """the checked resource should link these other bioimage.io resources"""
+
+
+def download_and_check_hash(url: str, sha256: str) -> bytes:
+    r = requests.get(url)
+    r.raise_for_status()
+    data = r.content
+
+    actual = hashlib.sha256(data).hexdigest()
+    if actual != sha256:
+        raise ValueError(
+            f"found sha256='{actual}' for downlaoded {url}, but exptected '{sha256}'"
+        )
+
+    return data
+
+
+def download_rdf(rdf_url: str, sha256: str) -> Dict[str, Any]:
+    rdf_data = download_and_check_hash(rdf_url, sha256)
+    rdf: Union[Any, Dict[Any, Any]] = yaml.load(rdf_data)
+    assert isinstance(rdf, dict)
+    assert all(isinstance(k, str) for k in rdf)
+    return rdf

--- a/scripts/upload_reports.py
+++ b/scripts/upload_reports.py
@@ -1,0 +1,46 @@
+import json
+import warnings
+from pathlib import Path
+from typing import Any, Dict, Union
+
+import fire
+from ruyaml import YAML
+
+from bioimageio_collection_backoffice.db_structure.compatibility import (
+    CompatiblityReport,
+)
+from bioimageio_collection_backoffice.remote_collection import (
+    get_remote_resource_version,
+)
+from bioimageio_collection_backoffice.s3_client import Client
+
+yaml = YAML(typ="safe")
+
+
+def upload_reports(reports: Path):
+    client = Client()
+    for p in reports.glob("*/*/compatibility/*"):
+        concept, version, _, tool_file_name = p.as_posix().split("/")
+        tool = tool_file_name[: -len(".yaml")]
+
+        if p.suffix in (".yml", ".yaml"):
+            with p.open("rt", encoding="utf-8") as f:
+                report_data: Union[Any, Dict[Any, Any]] = yaml.load(f)
+        elif p.suffix in (".json"):
+            with p.open("rt", encoding="utf-8") as f:
+                report_data = json.load(f)
+        else:
+            warnings.warn(f"ignoring '{p}' for its unknown suffix.")
+            continue
+
+        assert isinstance(report_data, dict)
+        report = CompatiblityReport(tool=tool, **report_data)
+
+        record = get_remote_resource_version(
+            client=client, concept_id=concept, version=version
+        )
+        record.set_compatibility_report(report)
+
+
+if __name__ == "__main__":
+    fire.Fire(upload_reports)


### PR DESCRIPTION
this PR splits the script checking for ilastik compatibility into generating compatibility reports and another script to upload them.

This avoids installing backoffice into the ilastik env and makes the upload part available to be reused for other community partner compatibility checks