### PR TITLE
Update partner docs URLs to BMZ-specific pages

### DIFF
--- a/bioimageio_collection_config.json
+++ b/bioimageio_collection_config.json
@@ -185,7 +185,7 @@
                         }
                     ],
                     "default_type": "model",
-                    "docs": "https://github.com/deepimagej/deepimagej-plugin/wiki",
+                    "docs": "https://deepimagej.github.io/",
                     "explore_button_text": "Start Exploring",
                     "icon": "https://raw.githubusercontent.com/deepimagej/models/master/logos/icon.png",
                     "id": "deepimagej",
@@ -354,7 +354,7 @@
                 {
                     "background_image": "static/img/zoo-background.svg",
                     "default_type": "model",
-                    "docs": "https://qupath.readthedocs.io/",
+                    "docs": "https://qupath.readthedocs.io/en/latest/docs/deep/bioimage.html",
                     "explore_button_text": "Start Exploring",
                     "icon": "https://raw.githubusercontent.com/qupath/qupath-bioimage-io/main/logos/QuPath_256.png",
                     "id": "qupath",
@@ -425,7 +425,7 @@
                         }
                     ],
                     "default_type": "model",
-                    "docs": "https://biapy.readthedocs.io/",
+                    "docs": "https://biapy.readthedocs.io/en/latest/get_started/bmz.html",
                     "explore_button_text": "Start Exploring",
                     "icon": "https://raw.githubusercontent.com/BiaPyX/BiaPy-bioimage-io/main/logos/BiaPy_256.png",
                     "id": "biapy",


### PR DESCRIPTION
## Summary

The `docs` field for each partner is now displayed as a clickable link on the model detail page in the BioImage Model Zoo website (see [bioimage-io/bioimage.io@bdbbcb1](https://github.com/bioimage-io/bioimage.io/commit/bdbbcb1)). This PR updates three partners to point to more specific, BMZ-related documentation pages instead of generic homepages.

### Changes

| Partner | Before | After |
|---------|--------|-------|
| **DeepImageJ** | `github.com/deepimagej/deepimagej-plugin/wiki` | `deepimagej.github.io/` (main docs site with tutorials) |
| **BiaPy** | `biapy.readthedocs.io/` | `biapy.readthedocs.io/en/latest/get_started/bmz.html` (dedicated BMZ guide) |
| **QuPath** | `qupath.readthedocs.io/` | `qupath.readthedocs.io/en/latest/docs/deep/bioimage.html` (BMZ integration page) |

### Request to partner maintainers

The `docs` URL for each partner is now shown to users as a documentation link next to the software name in the **Compatibilities** panel on each model's detail page. This helps users learn how to install and use your software with BioImage Model Zoo models.

**Could you please review the `docs` URL for your partner entry and consider:**

1. Does your current `docs` URL point to a page that helps users get started with BioImage Model Zoo models in your software?
2. If not, could you create a dedicated guide page (e.g., "How to use BioImage Model Zoo models in [your software]") and update the `docs` URL to point there?

Ideally each partner would have a page that covers:
- How to install the software
- How to load/import a model from the BioImage Model Zoo
- A quick example of running a BMZ model

cc @esgomezm @k-dominik @danifranco @maweigert @jansanrom @ElpadoCan

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)